### PR TITLE
Update license format and comment out license-files

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ maintainers = [
     {name="Alteryx, Inc.", email="open_source_support@alteryx.com"}
 ]
 keywords = ["data science", "machine learning", "optimization", "automl"]
-license = {text = "BSD 3-Clause License"}
+license = {text = "BSD-3-Clause"}
 requires-python = ">=3.9,<4"
 dependencies = [
     "numpy >= 1.22.0",
@@ -116,7 +116,7 @@ complete = [
 
 [tool.setuptools]
 include-package-data = true
-license-files = ["LICENSE"]
+#license-files = ["LICENSE"]
 
 [tool.setuptools.packages.find]
 namespaces = true


### PR DESCRIPTION
Standardized the license field to "BSD-3-Clause" for consistency. Commented out the "license-files" entry under setuptools to refine configuration. No functional impact expected.

### Pull Request Description
(replace this text with your description)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
