### PR TITLE
Fix license file inclusion in setuptools configuration

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -117,7 +117,7 @@ complete = [
 [tool.setuptools]
 include-package-data = true
 #license-files = ["LICENSE"]
-
+license-files = []
 [tool.setuptools.packages.find]
 namespaces = true
 


### PR DESCRIPTION
Re-enables the `license-files` setting in the `pyproject.toml` by setting it to an empty list. This ensures compatibility with setuptools package requirements while maintaining a clean configuration.

### Pull Request Description
(replace this text with your description)

-----
*After creating the pull request: in order to pass the **release_notes_updated** check you will need to update the "Future Release" section of* `docs/source/release_notes.rst` *to include this pull request by adding :pr:`123`.*
